### PR TITLE
Support PyCharm 2024.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also download the ZIP files manually from [the <i>Releases</i> tab][9],
 and follow the instructions described [here][12].
 
 Currently supported versions:
-2024.1 (build 241.14494.241) - 2024.2.* (build 242.*).
+2024.1 (build 241.14494.241) - 2024.3.* (build 243.*).
 
 
 ## Credits

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@ pluginVersion = 0.7.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241.14494.241
-pluginUntilBuild = 242.*
+pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = PC
-platformVersion = 2024.2
+platformVersion = 2024.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION
- [x] Increase support to new PyCharm version
- [x] Skimming though https://plugins.jetbrains.com/docs/intellij/api-changes-list-2024.html didn't result in any obvious changes 
- [x] Existing testcases are working
- [x] Run verifications don't create new exceptions on 2024.3 platform
- [x] Distributing the plugin as zip-file and testing it manually on an existing project worked without errors
@InSyncWithFoo The changelog & latest version number was not yet updated. I guess an update on the current architecture (without https://github.com/InSyncWithFoo/pyright-for-pycharm/issues/77 being merged) is needed until this refactoring-branch is merged.