### PR TITLE
Correctly handle `workspace/configuration` for `python`

### DIFF
--- a/src/main/kotlin/com/insyncwithfoo/pyright/lsp4ij/PyrightServerClient.kt
+++ b/src/main/kotlin/com/insyncwithfoo/pyright/lsp4ij/PyrightServerClient.kt
@@ -16,7 +16,7 @@ internal class PyrightServerClient(project: Project) : LanguageClientImpl(projec
         val settings = project.createLSPSettingsObject()
         
         return when (section) {
-            "python" -> settings
+            "python" -> settings.python
             "python.analysis" -> settings.python.analysis
             "pyright" -> settings.pyright
             else -> null


### PR DESCRIPTION
Resolves #109, resolves #111. See also #142.